### PR TITLE
비동기(Async-Await) 로직 개선

### DIFF
--- a/TCObjectStorageClient.Shared/ObjectStorage/ObjectStorageUrl.cs
+++ b/TCObjectStorageClient.Shared/ObjectStorage/ObjectStorageUrl.cs
@@ -1,0 +1,20 @@
+﻿namespace TCObjectStorageClient.ObjectStorage
+{
+    internal static class ObjectStorageUrl
+    {
+        internal static string UrlForToken()
+        {
+            return "https://api-compute.cloud.toast.com/identity/v2.0/tokens";
+        }
+
+        internal static string UrlForObject(string account, string containerName, string objectName)
+        {
+            return "https://api-storage.cloud.toast.com/v1/{account}/{containerName}/{objectName}";
+        }
+
+        internal static string UrlForContainer(string account, string containerName)
+        {
+            return "https://api-storage.cloud.toast.com/v1/{account}/{containerName}";
+        }
+    }
+}

--- a/TCObjectStorageClient.Shared/ObjectStorage/TCObjectStorage.cs
+++ b/TCObjectStorageClient.Shared/ObjectStorage/TCObjectStorage.cs
@@ -14,7 +14,7 @@ namespace TCObjectStorageClient.ObjectStorage
     {
         public async Task<string> PostToken(string tenentName, string userName, string password)
         {
-            var url = "https://api-compute.cloud.toast.com/identity/v2.0/tokens";
+            var url = ObjectStorageUrl.UrlForToken();
             HttpClient client = new HttpClient();
 
             var createTokenReqeust = new CreateTokenRequest
@@ -42,7 +42,7 @@ namespace TCObjectStorageClient.ObjectStorage
         public async Task<bool> UploadFile(string token, string account, string containerName, string objectName, byte[] body)
         {
             HttpClient client = new HttpClient();
-            var url = $"https://api-storage.cloud.toast.com/v1/{account}/{containerName}/{objectName}";
+            var url = ObjectStorageUrl.UrlForObject(account, containerName, objectName);
             client.DefaultRequestHeaders.Add("X-Auth-Token", token);
             var response = await client.PutAsync(url, new ByteArrayContent(body));
             return response.StatusCode == HttpStatusCode.Created;
@@ -51,7 +51,7 @@ namespace TCObjectStorageClient.ObjectStorage
         public async Task<(bool, List<string>)> GetFiles(string token, string account, string containerName)
         {
             HttpClient client = new HttpClient();
-            var url = $"https://api-storage.cloud.toast.com/v1/{account}/{containerName}";
+            var url = ObjectStorageUrl.UrlForContainer(account, containerName);
             client.DefaultRequestHeaders.Add("X-Auth-Token", token);
             var response = await client.GetAsync(url);
             var statusCode = (int)response.StatusCode;
@@ -72,7 +72,7 @@ namespace TCObjectStorageClient.ObjectStorage
         public async Task<bool> DeleteFile(string token, string account, string containerName, string objectName)
         {
             HttpClient client = new HttpClient();
-            var url = $"https://api-storage.cloud.toast.com/v1/{account}/{containerName}/{objectName}";
+            var url = ObjectStorageUrl.UrlForObject(account, containerName, objectName);
             client.DefaultRequestHeaders.Add("X-Auth-Token", token);
             var response = await client.DeleteAsync(url);
             return response.StatusCode == HttpStatusCode.NoContent;
@@ -81,7 +81,7 @@ namespace TCObjectStorageClient.ObjectStorage
         public async Task<bool> ContainsContainer(string token, string account, string containerName)
         {
             HttpClient client = new HttpClient();
-            var url = $"https://api-storage.cloud.toast.com/v1/{account}/{containerName}";
+            var url = ObjectStorageUrl.UrlForContainer(account, containerName);
             client.DefaultRequestHeaders.Add("X-Auth-Token", token);
             var response = await client.GetAsync(url);
             var statusCode = (int)response.StatusCode;

--- a/TCObjectStorageClient.Shared/TCObjectStorageClient.Shared.projitems
+++ b/TCObjectStorageClient.Shared/TCObjectStorageClient.Shared.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\IDiskEntity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ObjectStorage\IObjectStorage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ObjectStorage\TCObjectStorage.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ObjectStorage\ObjectStorageUrl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\MainViewModel.cs" />
   </ItemGroup>
 </Project>

--- a/TCObjectStorageClient/MainWindow.xaml
+++ b/TCObjectStorageClient/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:TCObjectStorageClient"
         mc:Ignorable="d"
-        Title="MainWindow" Height="350" Width="525">
+        Title="MainWindow" Height="250" Width="520" MinHeight="250" MaxHeight="250" MinWidth=" 520">
     <StackPanel Margin="10">
         <Grid>
             <Grid.ColumnDefinitions>


### PR DESCRIPTION
# 동기
- Await의 잘못된 이해로 인해 다량의 리퀘스트가 순차적으로 요청되는 현상 발생했다.

# 수정
- Task를 하나로 모아서 한꺼번에 확인할 수 있는 `Task.WhenAll(Task<T>)` 메소드 사용했다.

# 해결
- 아래와 같이 성능 향상이 되었다.

# 성능 측정
![image](https://user-images.githubusercontent.com/4951898/27007501-6f11c98e-4e90-11e7-98f7-d6ac29c0ad82.png)

